### PR TITLE
Add wchisp for additional upload method

### DIFF
--- a/package_ch32v_index.json
+++ b/package_ch32v_index.json
@@ -258,6 +258,13 @@
               "size": "829359"
             },
             {
+              "host": "aarch64-linux-gnu",
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/v0.2.3/wchisp-v0.2.3-linux-aarch64.tar.gz",
+              "archiveFileName": "wchisp-v0.2.3-linux-aarch64.tar.gz",
+              "checksum": "SHA-256:5f3f20a273d62b545085fccfa5640f4bf42ef70ccf17d6be87311951073450a1",
+              "size": "828826"
+            },
+            {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/ch32-rs/wchisp/releases/download/v0.2.3/wchisp-v0.2.3-macos-x64.tar.gz",
               "archiveFileName": "wchisp-v0.2.3-macos-x64.tar.gz",

--- a/package_ch32v_index.json
+++ b/package_ch32v_index.json
@@ -237,7 +237,42 @@
               "size": "507269"
             }				
           ]
-        }		
+        },
+        {
+          "name": "wchisp",
+          "version": "nightly",
+          "systems":
+          [
+            {
+              "host": "i686-mingw32",
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-win-x64.tar.gz",
+              "archiveFileName": "wchisp-win-x64.tar.gz",
+              "checksum": "SHA-256:76870ec869b410827208a20e07e8c2fe307c549480eb6192da3a186d959a060f",
+              "size": "656535"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-linux-x64.tar.gz",
+              "archiveFileName": "wchisp-linux-x64.tar.gz",
+              "checksum": "SHA-256:b4a651bef61bc96fd49f5d49cc310d2bd5a4658c1a48dc47a78f6ad3f2f99398",
+              "size": "843574"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-macos-x64.tar.gz",
+              "archiveFileName": "wchisp-macos-x64.tar.gz",
+              "checksum": "SHA-256:655e053088258f9cb21ad20f11326908f6cd4d42a633950101fd7737f62a66e0",
+              "size": "765124"
+            },
+            {
+              "host": "arm64-apple-darwin",
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-macos-arm64.tar.gz",
+              "archiveFileName": "wchisp-macos-arm64.tar.gz",
+              "checksum": "SHA-256:93e87cbbd693ad09a996ba883ba0058171b22dddbf3341af82ba366d965fe0c2",
+              "size": "765230"
+            }
+          ]
+        }
       ]
     }
   ]

--- a/package_ch32v_index.json
+++ b/package_ch32v_index.json
@@ -149,7 +149,7 @@
               "packager": "WCH",
               "name": "beforeinstall",
               "version": "1.0.0"
-            }			
+            }
           ]
         }		
       ],
@@ -240,36 +240,36 @@
         },
         {
           "name": "wchisp",
-          "version": "nightly",
+          "version": "0.2.3",
           "systems":
           [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-win-x64.tar.gz",
-              "archiveFileName": "wchisp-win-x64.tar.gz",
-              "checksum": "SHA-256:76870ec869b410827208a20e07e8c2fe307c549480eb6192da3a186d959a060f",
-              "size": "656535"
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/v0.2.3/wchisp-v0.2.3-win-x64.zip",
+              "archiveFileName": "wchisp-v0.2.3-win-x64.zip",
+              "checksum": "SHA-256:e17ac0ae743e25c080a539e6bb407c993e87583d4d6aeddcc0cd92ee681cc6cd",
+              "size": "629251"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-linux-x64.tar.gz",
-              "archiveFileName": "wchisp-linux-x64.tar.gz",
-              "checksum": "SHA-256:b4a651bef61bc96fd49f5d49cc310d2bd5a4658c1a48dc47a78f6ad3f2f99398",
-              "size": "843574"
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/v0.2.3/wchisp-v0.2.3-linux-x64.tar.gz",
+              "archiveFileName": "wchisp-v0.2.3-linux-x64.tar.gz",
+              "checksum": "SHA-256:b83c7cecf8b786d973cdf09d80869da0ccba48f22fed04cc753f15410f9c5dbc",
+              "size": "829359"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-macos-x64.tar.gz",
-              "archiveFileName": "wchisp-macos-x64.tar.gz",
-              "checksum": "SHA-256:655e053088258f9cb21ad20f11326908f6cd4d42a633950101fd7737f62a66e0",
-              "size": "765124"
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/v0.2.3/wchisp-v0.2.3-macos-x64.tar.gz",
+              "archiveFileName": "wchisp-v0.2.3-macos-x64.tar.gz",
+              "checksum": "SHA-256:635fd1b35e4d3101ec33ffdf6b93799103129225883c2d19cf1888eab4e230b9",
+              "size": "774784"
             },
             {
-              "host": "arm64-apple-darwin",
-              "url": "https://github.com/ch32-rs/wchisp/releases/download/nightly/wchisp-macos-arm64.tar.gz",
-              "archiveFileName": "wchisp-macos-arm64.tar.gz",
-              "checksum": "SHA-256:93e87cbbd693ad09a996ba883ba0058171b22dddbf3341af82ba366d965fe0c2",
-              "size": "765230"
+              "host": "aarch64-apple-darwin",
+              "url": "https://github.com/ch32-rs/wchisp/releases/download/v0.2.3/wchisp-v0.2.3-macos-arm64.tar.gz",
+              "archiveFileName": "wchisp-v0.2.3-macos-arm64.tar.gz",
+              "checksum": "SHA-256:8cbc83f0a5876e472f149d33131cc03c69c96c40fa731b44cb283e872d3a3e9d",
+              "size": "757891"
             }
           ]
         }


### PR DESCRIPTION
This PR add [wchisp](https://github.com/ch32-rs/wchisp) as tool dependency. This is used as  additional upload method with ch32 bootrom in https://github.com/openwch/arduino_core_ch32/pull/129. The binary from [wchisp release page](https://github.com/ch32-rs/wchisp/releases/tag/v0.2.3) can be used directly with Arduino json (we make a couple PR to wchisp to make it compatible with arduino IDE).

Once this is merged when releasing an new version e.g 1.0.5, we need to include this to `toolsDependencies` list.

```json
            {
              "packager": "WCH",
              "name": "wchisp",
              "version": "0.2.3"
            }
```


 Let me know if this makes sense to you.

@ladyada